### PR TITLE
Feat/bm 59/add begin date and end date fields on post

### DIFF
--- a/lib/src/models/post_model.dart
+++ b/lib/src/models/post_model.dart
@@ -1,22 +1,26 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:zona_hub/src/models/tag_model.dart';
 import 'package:zona_hub/src/models/user_model.dart';
 import 'package:zona_hub/src/utils/json_document_reference.dart';
 
 class Post {
-  Post({
-    this.id,
-    this.author,
-    this.authorData,
-    required this.title,
-    required this.description,
-    this.location,
-    this.createdAt,
-    required this.imageUrl,
-    this.ups = 0,
-    this.downs = 0,
-    this.tags,
-    this.community,
-  });
+  Post(
+      {this.id,
+      this.author,
+      this.authorData,
+      required this.title,
+      required this.description,
+      this.address,
+      this.location,
+      this.createdAt,
+      required this.imageUrl,
+      this.ups = 0,
+      this.downs = 0,
+      this.tags,
+      this.tagsData,
+      this.community,
+      this.beginDate,
+      required this.endDate});
 
   Post.fromJson(Map<String, dynamic> json)
       : this(
@@ -29,8 +33,9 @@ class Post {
               : null,
           title: json['title'] as String? ?? '',
           description: json['description'] as String? ?? '',
-          location: json['location'] as Map<String, dynamic>?,
-          createdAt: json['createdAt'] as String?,
+          location: json['location'] as GeoPoint?,
+          address: json['address'] as String?,
+          createdAt: json['createdAt'] as DateTime?,
           imageUrl: json['imageUrl'] as String? ?? '',
           ups: json['ups'] as int? ?? 0,
           downs: json['downs'] as int? ?? 0,
@@ -42,6 +47,10 @@ class Post {
           community: json['community'] != null
               ? JsonDocumentReference(json['community']).toDocumentReference()
               : null,
+          beginDate: json['beginDate'] != null
+              ? DateTime.parse(json['beginDate'])
+              : null,
+          endDate: DateTime.parse(json['endDate']),
         );
 
   late String? id;
@@ -49,13 +58,17 @@ class Post {
   late UserModel? authorData;
   final String title;
   final String description;
-  final Map<String, dynamic>? location;
-  final String? createdAt;
+  final GeoPoint? location;
+  final String? address;
+  final DateTime? createdAt;
   final String imageUrl;
   final int? ups;
   final int? downs;
-  final List<DocumentReference<Map<String, dynamic>>>? tags;
+  late List<DocumentReference<Map<String, dynamic>>>? tags;
+  late List<Tag>? tagsData;
   final DocumentReference<Map<String, dynamic>>? community;
+  final DateTime? beginDate;
+  final DateTime endDate;
 
   Map<String, Object?> toJson() {
     return {
@@ -63,12 +76,15 @@ class Post {
       'title': title,
       'description': description,
       if (location != null) 'location': location,
+      if (address != null) 'address': address,
       'createdAt': createdAt,
       'imageUrl': imageUrl,
       'ups': ups ?? 0,
       'downs': downs ?? 0,
       'tags': tags,
       if (community != null) 'community': community,
+      if (beginDate != null) 'beginDate': beginDate!.toIso8601String(),
+      'endDate': endDate.toIso8601String(),
     };
   }
 }

--- a/lib/src/models/tag_model.dart
+++ b/lib/src/models/tag_model.dart
@@ -1,3 +1,5 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 class Tag {
   Tag({this.id, required this.name});
   Tag.fromJson(Map<String, dynamic> json)
@@ -12,5 +14,9 @@ class Tag {
     return {
       'name': name,
     };
+  }
+
+  DocumentReference<Map<String, dynamic>> toDocumentReference() {
+    return FirebaseFirestore.instance.collection('tags').doc(id);
   }
 }

--- a/lib/src/services/post_service.dart
+++ b/lib/src/services/post_service.dart
@@ -18,7 +18,8 @@ class PostService {
   final TagService tagService = TagService();
 
   Stream<List<Post>> getPosts(
-      {PostQuery query = PostQuery.all, List<Tag> tags = const <Tag>[]}) {
+      {PostQuery query = PostQuery.beforeEndDate,
+      List<Tag> tags = const <Tag>[]}) {
     checkPostQueryParams(query: query, tags: tags);
     return postsRef
         .queryBy(query: query, tags: tags)
@@ -39,6 +40,9 @@ class PostService {
   Future<void> createPost(Post post) async {
     final user = await authService.getCurrentUser();
     post.author = user.toDocumentReference();
+    // set tags to the document reference of the tag
+    post.tags = post.tagsData!.map((tag) => tag.toDocumentReference()).toList();
+
     await postsRef.add(post);
   }
 }

--- a/lib/src/utils/post_query.dart
+++ b/lib/src/utils/post_query.dart
@@ -3,7 +3,7 @@ import 'package:zona_hub/src/models/post_model.dart';
 import 'package:zona_hub/src/models/tag_model.dart';
 import 'package:zona_hub/src/services/tag_service.dart';
 
-enum PostQuery { all, mine, tags }
+enum PostQuery { all, mine, tags, beforeEndDate }
 
 final TagService tagService = TagService();
 
@@ -21,12 +21,16 @@ extension QueryDuplication on Query<Post> {
             arrayContainsAny: tags
                 .map((tag) => tagService.getTagDocRefFromId(tag.id!))
                 .toList());
+      case PostQuery.beforeEndDate:
+        return this
+            .where('endDate', isGreaterThanOrEqualTo: DateTime.now().toIso8601String());
     }
   }
 }
 
 void checkPostQueryParams(
-    {PostQuery query = PostQuery.all, List<Tag> tags = const <Tag>[]}) {
+    {PostQuery query = PostQuery.beforeEndDate,
+    List<Tag> tags = const <Tag>[]}) {
   if (query == PostQuery.tags && tags.isEmpty) {
     throw ArgumentError('Tags cannot be empty when query is PostQuery.tags');
   }


### PR DESCRIPTION
Hola chaviza!
En este ocasión, en este pull requisito se agregan los campos de begindate and enddate para poder filtrar los posts actuales.
Luego tambien, podrás crear un post y pasar una lista de objetos Tags, mediante el campo tagsData.

Atte. Bruno Montaputas